### PR TITLE
Set `CC=$CC` override to counteract Openlibm's opinionated build system.

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -12,21 +12,24 @@ script = raw"""
 cd ${WORKSPACE}/srcdir/openlibm-*
 
 # Install into output
-flags="prefix=${prefix}"
+flags=("prefix=${prefix}")
 
 # Build ARCH from ${target}
-flags="${flags} ARCH=${target%-*-*}"
+flags+=("ARCH=${target%-*-*}")
 
 # Openlibm build system doesn't recognize our windows cross compilers properly
 if [[ ${target} == *mingw* ]]; then
-    flags="${flags} OS=WINNT"
+    flags+=("OS=WINNT")
 fi
 
+# Add `CC` override, since Openlibm seems to think it knows best:
+flags+=("CC=$CC")
+
 # Build the library
-make ${flags} -j${nproc}
+make "${flags[@]}" -j${nproc}
 
 # Install the library
-make ${flags} install
+make "${flags[@]}" install
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
Also switch to using a `bash` array for `$flags` so that spaces aren't a problem.